### PR TITLE
Run Molecule tests using `ansible-core~=2.18`

### DIFF
--- a/.github/workflows/molecule-latest.yml
+++ b/.github/workflows/molecule-latest.yml
@@ -17,7 +17,8 @@ jobs:
     steps:
       - name: Install Ansible Molecule.
         run: |
-          pip3 install --user molecule molecule-plugins[podman] ansible-core
+          pip3 install --user molecule molecule-plugins[podman] ansible-core~=2.18.7
+          # `ansible-core~=2.18.7` is a workaround for https://github.com/ansible-community/molecule-plugins/issues/311
 
       - name: Check out the codebase.
         uses: actions/checkout@v3

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -22,7 +22,8 @@ jobs:
     steps:
       - name: Install Ansible Molecule.
         run: |
-          pip3 install --user molecule molecule-plugins[podman] ansible-core
+          pip3 install --user molecule molecule-plugins[podman] ansible-core~=2.18.7
+          # `ansible-core~=2.18.7` is a workaround for https://github.com/ansible-community/molecule-plugins/issues/311
 
       - name: Check out the codebase.
         uses: actions/checkout@v3


### PR DESCRIPTION
Workaround for issue X, triggered by the recent update of `ansible-core` to version 2.19.