### PR TITLE
Switch Ansible Lint action to `ansible/ansible-lint`

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run ansible-lint
-        uses: ansible/ansible-lint-action@v6
+        uses: ansible/ansible-lint@v25
 
   yamllint:
     name: YAML Lint


### PR DESCRIPTION
The "Code style" workflow is using `ansible/ansible-lint-action`, but it is no longer available because it is now included in the `ansible/ansible-lint` GitHub repository. Switch to the new location.